### PR TITLE
first commit

### DIFF
--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -39,6 +39,13 @@ class FurimasController < ApplicationController
     end
   end
 
+  def destroy
+    furima = Furima.find(params[:id])
+    furima.destroy
+    redirect_to root_path
+  end
+
+
   private
 
   def set_furima

--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,7 +1,7 @@
 class FurimasController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_furima, only: [:edit, :show, :update]
+  before_action :set_furima, only: [:edit, :show, :update, :destroy]
   
   def index
     @furimas = Furima.includes(:user).order("created_at DESC")
@@ -40,9 +40,12 @@ class FurimasController < ApplicationController
   end
 
   def destroy
-    furima = Furima.find(params[:id])
-    furima.destroy
-    redirect_to root_path
+    if user_signed_in? && current_user.id == @furima.user_id
+      @furima.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
   end
 
 

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -27,7 +27,7 @@
       <% if user_signed_in? && current_user.id == @furima.user_id %>
         <%= link_to '商品の編集', edit_furima_path(@furima.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', furima_path, method: :delete, class:'item-destroy' %>
       <% end %>
       
       <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'furimas#index'
-  resources :furimas, only: [:index, :new, :create, :show, :edit, :update] do
+  resources :furimas  do
     resources :purchases, only: [:index, :create]
   end
 end


### PR DESCRIPTION
what
商品解除機能の実装

why
間違って出品をしてしまった場合にそれが売れてしまってはいけないので、
商品を解除する際に商品解除機能が必要なので実装しました